### PR TITLE
Add API Reference link to header navigation

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -75,7 +75,8 @@ export default defineConfig({
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      { text: 'Guide', link: '/guide/getting-started', activeMatch: '/guide/' }
+      { text: 'Guide', link: '/guide/getting-started', activeMatch: '/guide/' },
+      { text: 'API Reference', link: 'https://api.soil-kt.com/' }
     ],
 
     sidebar: {


### PR DESCRIPTION
Placed a link to the API Reference next to the Guide.

<img width="720" alt="スクリーンショット 2024-04-29 17 31 12" src="https://github.com/soil-kt/soil-docs/assets/1496485/0650f5fa-d2d2-433b-b7c8-eba1e7c35e8a">
