### PR TITLE
Removed warnings in getting-started.md due to fixes in the update to 1.6.10

### DIFF
--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -14,11 +14,6 @@ Currently, the only browsers that support WasmGC are Chrome and Firefox.
 For the latest compatibility information, please visit https://webassembly.org/features/.
 :::
 
-::: warning Known Issues
-We are aware of an issue with Kotlin Wasm on mobile browsers where the app's screen size may not adjust correctly.  
-[compose-multiplatform #4620](https://github.com/JetBrains/compose-multiplatform/issues/4620)
-:::
-
 
 ## Download
 

--- a/ja/guide/getting-started.md
+++ b/ja/guide/getting-started.md
@@ -14,11 +14,6 @@ Source code: <https://github.com/soil-kt/soil/tree/main/sample/>
 最新の対応状況は https://webassembly.org/features/ を確認してください。
 :::
 
-::: warning 既知の問題
-モバイルブラウザで試すと、アプリの画面サイズが正しく調整されない Kotlin Wasm の問題を把握しています。
-[compose-multiplatform #4620](https://github.com/JetBrains/compose-multiplatform/issues/4620)
-:::
-
 
 ## Download
 


### PR DESCRIPTION
refs: https://github.com/soil-kt/soil/pull/12