### PR TITLE
The code in the "Hello Query" tutorial guide was incorrect

### DIFF
--- a/guide/query/hello-query.md
+++ b/guide/query/hello-query.md
@@ -60,7 +60,8 @@ Query provides APIs named `rememberXxx` for each type of Key.
 fun App() {
     SwrClientProvider(client = swrClient) {
         MaterialTheme {
-            when (val query = rememberQuery(HelloQueryKey())) {
+            val key = remember { HelloQueryKey() }
+            when (val query = rememberQuery(key)) {
                 is QuerySuccessObject -> Text(query.data)
                 is QueryLoadingObject -> Text("Loading...")
                 is QueryLoadingErrorObject,
@@ -87,7 +88,8 @@ fun App() {
         MaterialTheme {
             ErrorBoundary(fallback = { Text("Error :(") }) {
                 Suspense(fallback = { Text("Loading...") }) {
-                    val query = rememberQuery(HelloQueryKey())
+                    val key = remember { HelloQueryKey() }
+                    val query = rememberQuery(key)
                     Await(query) { result ->
                         Text(result)
                     }

--- a/ja/guide/query/hello-query.md
+++ b/ja/guide/query/hello-query.md
@@ -59,7 +59,8 @@ Query には、 Key のタイプごとに `rememberXxx` という API が用意�
 fun App() {
     SwrClientProvider(client = swrClient) {
         MaterialTheme {
-            when (val query = rememberQuery(HelloQueryKey())) {
+            val key = remember { HelloQueryKey() }
+            when (val query = rememberQuery(key)) {
                 is QuerySuccessObject -> Text(query.data)
                 is QueryLoadingObject -> Text("Loading...")
                 is QueryLoadingErrorObject,
@@ -85,7 +86,8 @@ fun App() {
         MaterialTheme {
             ErrorBoundary(fallback = { Text("Error :(") }) {
                 Suspense(fallback = { Text("Loading...") }) {
-                    val query = rememberQuery(HelloQueryKey())
+                    val key = remember { HelloQueryKey() }
+                    val query = rememberQuery(key)
                     Await(query) { result ->
                         Text(result)
                     }


### PR DESCRIPTION
The definition of the remember function for the key was missing.